### PR TITLE
Migrate to Onnx

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,14 +6,13 @@ Flutter app for offline bird identification
 
 For the detecting task, we uses pretrained model `yolo11n`.
 
-For the classification task, `ResNet34` model structure was adopted, take [MetaFGNet/L_Bird_pretrain/checkpoints](https://drive.google.com/drive/folders/1gsct7uWHYPfmNmFvLVHlgFqKOcoQRzs9) as a pretrained model, trained on [DongNiao DIB-10K](https://www.researchgate.net/publication/344639013).
+For the classification task, `ResNet34` model structure was adopted, take [MetaFGNet/L_Bird_pretrain/checkpoints](https://drive.google.com/drive/folders/1gsct7uWHYPfmNmFvLVHlgFqKOcoQRzs9) as a pretrained model, trained on [DongNiao DIB-10K](https://www.researchgate.net/publication/344639013) using [Gorilla-Lab-SCUT/MetaFGNet](https://github.com/Gorilla-Lab-SCUT/MetaFGNet).
 
 Structure of `assets` folder:
 - assets
     - icons (all in git)
     - labels
         - [bird_info.json](https://github.com/sun-jiao/MetaFGNet/releases)
-        - [yolo_labels.txt](https://github.com/abdelaziz-mahdy/pytorch_lite/blob/4d4ec5b397d676101c2544555fc6a2421f5b3b09/example/assets/labels/labels_objectDetection_Coco.txt)
     - models
-        - bird_model.pt (convert [model20240824.pth](https://github.com/sun-jiao/MetaFGNet/releases) using [export_model.py](https://github.com/sun-jiao/bio_image_downloader/blob/3154767593f591c3517aabd79bae3a83d057217c/export_model.py))
-        - yolo11n.pt (`yolo mode=export model=yolo11n.pt format=torchscript optimize`)
+        - bird_model.onnx (convert [model20240824.pth](https://github.com/sun-jiao/MetaFGNet/releases) to onnx)
+        - ssd_mobilenet.onnx (pre-trained model from [onnx modelzoo](https://github.com/onnx/models/tree/main/validated/vision/object_detection_segmentation/ssd-mobilenetv1))

--- a/lib/entities/ai_tools.dart
+++ b/lib/entities/ai_tools.dart
@@ -13,8 +13,7 @@ class AiTools {
 
   static Future<void> _initDetectModel() async {
     final sessionOptions = OrtSessionOptions();
-    final rawAssetFile =
-        await rootBundle.load("assets/models/ssd_mobilenet.onnx");
+    final rawAssetFile = await rootBundle.load("assets/models/ssd_mobilenet.onnx");
     final bytes = rawAssetFile.buffer.asUint8List();
     _detectModel = OrtSession.fromBuffer(bytes, sessionOptions);
   }
@@ -65,8 +64,7 @@ class AiTools {
     final inputTensor = Float32List.fromList(rgbaTensor);
     final shape = [1, 3, 224, 224];
 
-    final inputOrt =
-        OrtValueTensor.createTensorWithDataList(inputTensor, shape);
+    final inputOrt = OrtValueTensor.createTensorWithDataList(inputTensor, shape);
 
     final inputs = {_classifyModel!.inputNames[0]: inputOrt};
     final runOptions = OrtRunOptions();

--- a/lib/entities/ai_tools.dart
+++ b/lib/entities/ai_tools.dart
@@ -1,22 +1,49 @@
+import 'dart:async';
 import 'dart:typed_data';
 
+import 'package:flutter/services.dart';
+import 'package:onnxruntime/onnxruntime.dart';
 import 'package:pytorch_lite/pytorch_lite.dart';
+import 'package:image/image.dart' as img;
+
+import 'detection_result.dart';
 
 class AiTools {
   static ClassificationModel? _classifyModel;
-  static ModelObjectDetection? _detectModel;
+  static OrtSession? _classifyModelOnnx;
+  static OrtSession? _detectModel;
 
-  static Future<List<ResultObjectDetection>> birdDetect(Uint8List file) async {
+  static Future<void> _initDetectModel() async {
+    final sessionOptions = OrtSessionOptions();
+    final rawAssetFile = await rootBundle.load("assets/models/ssd_mobilenet.onnx");
+    final bytes = rawAssetFile.buffer.asUint8List();
+    _detectModel = OrtSession.fromBuffer(bytes, sessionOptions);
+  }
+
+  static Future<List<DetectionResult>> birdDetect(Uint8List file) async {
     while (_detectModel == null) {
-      _detectModel = await PytorchLite.loadObjectDetectionModel(
-          "assets/models/yolo11n.pt", 80, 640, 640,
-          labelPath: "assets/labels/yolo_labels.txt",
-          objectDetectionModelType: ObjectDetectionModelType.yolov8);
+      await _initDetectModel();
     }
 
-    List<ResultObjectDetection> objDetect = await _detectModel!.getImagePrediction(file);
+    img.Image image = img.decodeImage(file)!;
+    final input = image.getBytes(order: img.ChannelOrder.rgb);
+    final shape = [1, image.height, image.width, 3];
+    final inputOrt = OrtValueTensor.createTensorWithDataList(input, shape);
 
-    return objDetect.where((e) => e.className == "bird").toList();
+    final inputs = {_detectModel!.inputNames[0]: inputOrt};
+    final runOptions = OrtRunOptions();
+    final outputs = await _detectModel!.runAsync(runOptions, inputs);
+    inputOrt.release();
+    runOptions.release();
+    final boxes = (outputs![0]!.value as List<List<List<double>>>)[0];
+    final classes = (outputs[1]!.value as List<List<double>>)[0];
+    final scores = (outputs[2]!.value as List<List<double>>)[0];
+    final count = (outputs[3]!.value as List)[0] as double;
+    for (var element in outputs) {
+      element?.release();
+    }
+
+    return List.generate(count.toInt(), (i) => DetectionResult(boxes[i], classes[i].toInt(), scores[i]));
   }
 
   static Future<List<double>> birdID(Uint8List image) async {
@@ -26,5 +53,55 @@ class AiTools {
     }
 
     return await _classifyModel!.getImagePredictionList(image);
+  }
+
+  static Future<void> _initClassifyModel() async {
+    final sessionOptions = OrtSessionOptions();
+    final rawAssetFile = await rootBundle.load("assets/models/bird_model.onnx");
+    final bytes = rawAssetFile.buffer.asUint8List();
+    _classifyModelOnnx = OrtSession.fromBuffer(bytes, sessionOptions);
+  }
+
+  static Future<List<double>> birdIDOnnx(Uint8List image0) async {
+    while (_classifyModelOnnx == null) {
+      await _initClassifyModel();
+    }
+
+    img.Image image = img.decodeImage(image0)!;
+    image = img.copyResize(image, width: 224, height: 224);
+
+    final rgbaTensor = await _imageToFloatTensor(image);
+    final inputTensor = Float32List.fromList(rgbaTensor);
+    final shape = [1, 3, 224, 224];
+
+    final inputOrt = OrtValueTensor.createTensorWithDataList(inputTensor, shape);
+
+    final sessionOptions = OrtSessionOptions();
+    final rawAssetFile = await rootBundle.load("assets/models/bird_model.onnx");
+    final bytes = rawAssetFile.buffer.asUint8List();
+    final session = OrtSession.fromBuffer(bytes, sessionOptions);
+
+    final inputs = {session.inputNames[0]: inputOrt};
+    final runOptions = OrtRunOptions();
+    final outputs = await session.runAsync(runOptions, inputs);
+    inputOrt.release();
+    runOptions.release();
+    final result = (outputs![0]!.value as List);
+    for (var element in outputs) {
+      element?.release();
+    }
+    return result[0] as List<double>;
+  }
+
+  static Future<List<double>> _imageToFloatTensor(img.Image image) async {
+    final imageAsFloatBytes = image.getBytes(order: img.ChannelOrder.rgba);
+    final rgbaUints = Uint8List.view(imageAsFloatBytes.buffer);
+
+    final indexed = rgbaUints.indexed;
+    return [
+      ...indexed.where((e) => e.$1 % 4 == 0).map((e) => e.$2.toDouble()),
+      ...indexed.where((e) => e.$1 % 4 == 1).map((e) => e.$2.toDouble()),
+      ...indexed.where((e) => e.$1 % 4 == 2).map((e) => e.$2.toDouble()),
+    ];
   }
 }

--- a/lib/entities/ai_tools.dart
+++ b/lib/entities/ai_tools.dart
@@ -12,9 +12,9 @@ class AiTools {
   static OrtSession? _detectModel;
 
   static Future<void> _initDetectModel() async {
-    final sessionOptions = OrtSessionOptions();
     final rawAssetFile = await rootBundle.load("assets/models/ssd_mobilenet.onnx");
     final bytes = rawAssetFile.buffer.asUint8List();
+    final sessionOptions = OrtSessionOptions();
     _detectModel = OrtSession.fromBuffer(bytes, sessionOptions);
   }
 
@@ -46,9 +46,9 @@ class AiTools {
   }
   
   static Future<void> _initClassifyModel() async {
-    final sessionOptions = OrtSessionOptions();
     final rawAssetFile = await rootBundle.load("assets/models/bird_model.onnx");
     final bytes = rawAssetFile.buffer.asUint8List();
+    final sessionOptions = OrtSessionOptions();
     _classifyModel = OrtSession.fromBuffer(bytes, sessionOptions);
   }
 
@@ -78,6 +78,7 @@ class AiTools {
     return result[0] as List<double>;
   }
 
+  // normalize image
   static Future<List<double>> _imageToFloatTensor(img.Image image,
       {List<double> mean = const [0.485, 0.456, 0.406],
       List<double> std = const [0.229, 0.224, 0.225]}) async {

--- a/lib/entities/detection_result.dart
+++ b/lib/entities/detection_result.dart
@@ -1,0 +1,24 @@
+class DetectionBox {
+  DetectionBox(this.top, this.left, this.bottom, this.right);
+  final double left;
+  final double top;
+  final double right;
+  final double bottom;
+
+  double get width => right - left;
+  double get height => bottom - top;
+}
+
+class DetectionResult {
+  DetectionResult(
+    List<double> box,
+    this.cls,
+    this.score,
+  ) {
+    this.box = DetectionBox(box[0], box[1], box[2], box[3]);
+  }
+
+  late final DetectionBox box;
+  final int cls;
+  final double score;
+}

--- a/lib/entities/tools.dart
+++ b/lib/entities/tools.dart
@@ -2,11 +2,11 @@ import 'dart:math' as math;
 import 'dart:typed_data';
 
 import 'package:flutter/material.dart';
-import 'package:pytorch_lite/pigeon.dart';
 import 'package:image/image.dart' as img;
 
 import '../entities/predict_result.dart';
 import '../pages/manually_crop_page.dart';
+import 'detection_result.dart';
 
 // convert predict result to probabilities
 // take the Python code in Chinese Wikipedia as a reference:
@@ -36,7 +36,7 @@ List<PredictResult> getTop(List<double> probs, {
       .toList();
 }
 
-Future<Uint8List?> autoCrop(Uint8List imageData, PyTorchRect rect) async {
+Future<Uint8List?> autoCrop(Uint8List imageData, DetectionBox box) async {
   final decoded = img.decodeImage(imageData);
 
   if (decoded == null) {
@@ -46,10 +46,10 @@ Future<Uint8List?> autoCrop(Uint8List imageData, PyTorchRect rect) async {
   final int imageWidth = decoded.width;
   final int imageHeight = decoded.height;
 
-  final int left = (imageWidth * rect.left).floor();
-  final int width = (imageWidth * rect.width).floor();
-  final int top = (imageHeight * rect.top).floor();
-  final int height = (imageHeight * rect.height).floor();
+  final int left = (imageWidth * box.left).floor();
+  final int width = (imageWidth * box.width).floor();
+  final int top = (imageHeight * box.top).floor();
+  final int height = (imageHeight * box.height).floor();
 
   final cropped =
       img.copyCrop(decoded, x: left, y: top, width: width, height: height);

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,7 +1,6 @@
-import 'dart:io';
-
 import 'package:flutter/material.dart';
 import 'package:flutter_localization/flutter_localization.dart';
+import 'package:onnxruntime/onnxruntime.dart';
 
 import 'entities/localization_mixin.dart';
 import 'entities/predict_result.dart';
@@ -10,6 +9,7 @@ import 'pages/predict_page.dart';
 
 Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
+  OrtEnv.instance.init();
   await Future.wait([
     FlutterLocalization.instance.ensureInitialized(),
     PredictResult.loadSpeciesInfo(),
@@ -46,6 +46,12 @@ class _MyAppState extends State<MyApp> {
     _localization.onTranslatedLanguage = _onTranslatedLanguage;
     _localization.translate(SharedPrefTool.uiLanguage);
     super.initState();
+  }
+
+  @override
+  void dispose() {
+    OrtEnv.instance.release();
+    super.dispose();
   }
 
   void _onTranslatedLanguage(Locale? locale) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -41,7 +41,6 @@ dependencies:
   image_picker: ^1.1.2
   onnxruntime: ^1.4.1
   path_provider: ^2.1.5
-  pytorch_lite: ^4.3.1+1
   shared_preferences: ^2.3.4
 
 dev_dependencies:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -39,6 +39,7 @@ dependencies:
   flutter_localization: ^0.3.0
   image: ^4.5.2
   image_picker: ^1.1.2
+  onnxruntime: ^1.4.1
   path_provider: ^2.1.5
   pytorch_lite: ^4.3.1+1
   shared_preferences: ^2.3.4


### PR DESCRIPTION
The main reason is that thinks that their [AGPL license applies to the weights](https://github.com/ultralytics/ultralytics/issues/2129). Because of that, this project should also be licensed under AGPL. So I changed the object detection model. However, pytorch_lite [has some issue in loading SSDLite model](https://github.com/pytorch/pytorch/issues/143565). So I turned to [onnxruntime](https://github.com/gtbluesky/onnxruntime_flutter) library. However, having two ml framework will bloat the size. So I migrated the classification model to onnx too. 

Known issue: Because async and sync codes are excuted in the same thread, UI always freezes when loading models. And currently it's impossible to call Platform Channel method in Isolate. So there is no way to load models without freezing UI.